### PR TITLE
Make LICENSE clearly MIT.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+The MIT License
+
 Copyright (c) 2013 Dominion Enterprises
 
 Permission is hereby granted, free of charge, to any person


### PR DESCRIPTION
This is to help others less familiar with the text of the license to find information on the license.
