### PR TITLE
Mainly stream support, multi ack, message object

### DIFF
--- a/DominionEnterprises.Mongo.Tests/QueueTests.cs
+++ b/DominionEnterprises.Mongo.Tests/QueueTests.cs
@@ -47,6 +47,23 @@ namespace DominionEnterprises.Mongo.Tests
         {
             new Queue(string.Empty, string.Empty, null);
         }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ConstructWithNullCollectionObject()
+        {
+            new Queue(null);
+        }
+
+        [Test]
+        public void ConstructCollectionObject()
+        {
+            var collection = new MongoClient(ConfigurationManager.AppSettings["mongoQueueUrl"])
+                .GetServer()
+                .GetDatabase(ConfigurationManager.AppSettings["mongoQueueDb"])
+                .GetCollection(ConfigurationManager.AppSettings["mongoQueueCollection"]);
+            new Queue(collection);
+        }
         #endregion
 
         #region EnsureGetIndex

--- a/DominionEnterprises.Mongo/Queue.cs
+++ b/DominionEnterprises.Mongo/Queue.cs
@@ -11,7 +11,7 @@ using MongoDB.Driver.GridFS;
 using System.IO;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyVersion("1.2.1.*"), InternalsVisibleTo("DominionEnterprises.Mongo.Tests")]
+[assembly: AssemblyVersion("2.0.0.*"), InternalsVisibleTo("DominionEnterprises.Mongo.Tests")]
 
 namespace DominionEnterprises.Mongo
 {

--- a/DominionEnterprises.Mongo/Queue.cs
+++ b/DominionEnterprises.Mongo/Queue.cs
@@ -9,8 +9,9 @@ using System.Security.Cryptography;
 using System.Collections.Generic;
 using MongoDB.Driver.GridFS;
 using System.IO;
+using System.Runtime.CompilerServices;
 
-[assembly: AssemblyVersion("1.2.1.*")]
+[assembly: AssemblyVersion("1.2.1.*"), InternalsVisibleTo("DominionEnterprises.Mongo.Tests")]
 
 namespace DominionEnterprises.Mongo
 {
@@ -562,7 +563,7 @@ namespace DominionEnterprises.Mongo
         /// <returns>
         /// random double.
         /// </returns>
-        public static double GetRandomDouble(double min, double max)
+        internal static double GetRandomDouble(double min, double max)
         {
             if (Double.IsNaN(min)) throw new ArgumentException("min cannot be NaN");
             if (Double.IsNaN(max)) throw new ArgumentException("max cannot be NaN");

--- a/DominionEnterprises.Mongo/Queue.cs
+++ b/DominionEnterprises.Mongo/Queue.cs
@@ -353,6 +353,7 @@ namespace DominionEnterprises.Mongo
         /// <param name="earliestGet">earliest instant that a call to Get() can return message</param>
         /// <param name="priority">priority for order out of Get(). 0 is higher priority than 1</param>
         /// <exception cref="ArgumentNullException">handle or payload is null</exception>
+        /// <exception cref="ArgumentException">priority was NaN</exception>
         public void AckSend(Handle handle, BsonDocument payload, DateTime earliestGet, double priority)
         {
             AckSend(handle, payload, earliestGet, priority, true);

--- a/DominionEnterprises.Mongo/Queue.cs
+++ b/DominionEnterprises.Mongo/Queue.cs
@@ -45,6 +45,18 @@ namespace DominionEnterprises.Mongo
             this.collection = new MongoClient(url).GetServer().GetDatabase(db).GetCollection(collection);
         }
 
+        /// <summary>
+        /// Construct MongoQueue
+        /// </summary>
+        /// <param name="collection">collection</param>
+        /// <exception cref="ArgumentNullException">collection is null</exception>
+        public Queue(MongoCollection collection)
+        {
+            if (collection == null) throw new ArgumentNullException("collection");
+
+            this.collection = collection;
+        }
+
         #region EnsureGetIndex
         /// <summary>
         /// Ensure index for Get() method with no fields before or after sort fields

--- a/travisCoverageConfig.json
+++ b/travisCoverageConfig.json
@@ -4,7 +4,7 @@
     ],
     "methodBodyExcludes": [
         {
-            "method": "MongoDB.Bson.BsonDocument DominionEnterprises.Mongo.Queue::Get(MongoDB.Driver.QueryDocument,System.TimeSpan,System.TimeSpan,System.TimeSpan,System.Boolean)",
+            "method": "DominionEnterprises.Mongo.Message DominionEnterprises.Mongo.Queue::Get(MongoDB.Driver.QueryDocument,System.TimeSpan,System.TimeSpan,System.TimeSpan,System.Boolean)",
             "lines": ["poll = TimeSpan.FromMilliseconds(int.MaxValue);", "throw e;//cant cover"]
         }
     ]


### PR DESCRIPTION
Main purpose here is to use within datax so we can make feed level queries for translations/enumerations etc at the start of a feed or job and then each item only needs to pull the data set out of mongo via these streams. Its just normalization on the fly because each item currently still gets the information out of mongo, but this way its all compacted into as few docs as possible (will usually be 1) so will be MUCH faster (assuming the deserialization doesn't overwhelm) since now it gets thousands of docs per item. Will profile this on QA of course.
